### PR TITLE
#53 Fix labeling experience

### DIFF
--- a/src/pages/home/ProjectButton.tsx
+++ b/src/pages/home/ProjectButton.tsx
@@ -25,7 +25,7 @@ export const ProjectButton: React.FC<IProjectButtonProps> = ({
       className="projectBtn-btn"
       fill="outline"
       onClick={() => {
-        history.push(`/label/${projectId}`);
+        window.location.href = `/label/${projectId}`;
       }}
     >
       <div

--- a/src/pages/labelscreen/LabelScreen.tsx
+++ b/src/pages/labelscreen/LabelScreen.tsx
@@ -130,7 +130,7 @@ const LabelScreen: React.FC = () => {
       {showHelp && (
         <HelpComponent projectInfo={projectInfo} setShowHelp={setShowHelp} />
       )}
-      {showWin && <WinComponent />}
+      {showWin && <WinComponent setShowWin={setShowWin} />}
     </IonPage>
   );
 };

--- a/src/pages/labelscreen/components/CardLabelComponent.tsx
+++ b/src/pages/labelscreen/components/CardLabelComponent.tsx
@@ -136,7 +136,7 @@ const CardLabelComponent: React.FC<Props> = ({
         setTimeout(() => {
           style.transform = "none";
           setResetAnimation(false);
-        }, 10);
+        }, 50);
         setResetAnimation(true);
 
         ["up", "down", "left", "right"].forEach((dir) => {
@@ -210,7 +210,7 @@ const CardLabelComponent: React.FC<Props> = ({
         setTimeout(() => {
           style.transform = "none";
           setResetAnimation(false);
-        }, 10);
+        }, 50);
         setResetAnimation(true);
 
         ["up", "down", "left", "right"].forEach((dir) => {

--- a/src/pages/labelscreen/components/WinComponent.tsx
+++ b/src/pages/labelscreen/components/WinComponent.tsx
@@ -5,12 +5,13 @@ import './HelpComponent.css';
 import {returnDownBackOutline} from "ionicons/icons";
 import {useHistory} from "react-router-dom";
 
-const WinComponent: React.FC = () => {
+const WinComponent: React.FC<{setShowWin: (isShowWin: boolean) => void;}> = ({setShowWin}) => {
 
     const history = useHistory();
 
     const returnActionHandler = function returnActionHandler() {
         history.push('/home');
+        setShowWin(false);
     }
 
     return (


### PR DESCRIPTION
- Set Wincomponent to false after returning.
- Navigate to labeling via window location href to prevent useEffect hooks to not be triggered again
- Add longer delay to give card time to reload (quick fix)


Closes #53 